### PR TITLE
perf: replace colorjs.io with @colordx/core

### DIFF
--- a/index.test.ts
+++ b/index.test.ts
@@ -51,19 +51,19 @@ describe('convert', () => {
 		}
 	})
 
-	test('the convert fn parses wide-gamut and CIE color spaces', () => {
-		// All of these are equivalent to `red` (#ff0000)
-		const colors = [
-			'lab(54.2905414047 80.8049283205 69.8909647686)',
-			'lch(54.2905414047 106.8371817167 40.8576564524)',
-			'hwb(0 0% 0%)',
-			'color(display-p3 0.9174875573 0.2002868079 0.1385605911)',
-			'color(a98-rgb 0.8585916023 0 0)',
-			'color(prophoto-rgb 0.7022480752 0.275720531 0.1035476647)',
-			'color(rec2020 0.7919771358 0.2309756849 0.0737614751)',
-		]
-
-		for (let color of colors) {
+	// All of these are equivalent to `red` (#ff0000)
+	const wide_gamut_colors = [
+		'lab(54.2905414047 80.8049283205 69.8909647686)',
+		'lch(54.2905414047 106.8371817167 40.8576564524)',
+		'hwb(0 0% 0%)',
+		'color(display-p3 0.9174875573 0.2002868079 0.1385605911)',
+		'color(a98-rgb 0.8585916023 0 0)',
+		'color(prophoto-rgb 0.7022480752 0.275720531 0.1035476647)',
+		'color(rec2020 0.7919771358 0.2309756849 0.0737614751)',
+	]
+	test.each(wide_gamut_colors)(
+		'the convert fn parses wide-gamut and CIE color spaces: %s',
+		(color) => {
 			let converted = convert(color)
 			let hue_distance = Math.min(converted.hue, 360 - converted.hue)
 			expect(hue_distance, `Failed hue for '${color}', got ${converted.hue}`).toBeLessThan(0.01)
@@ -77,8 +77,8 @@ describe('convert', () => {
 			).toBeCloseTo(50, 1)
 			expect(converted.alpha).toBe(1)
 			expect(converted.authored).toBe(color)
-		}
-	})
+		},
+	)
 
 	const invalid_colors = ['hsl(0, 0, 0)', 'rgb(0 0 0 1)', 'rgb(a, b, c, 1)']
 	test.each(invalid_colors)(`invalid colors return a default object: %s`, (color) => {

--- a/index.test.ts
+++ b/index.test.ts
@@ -51,6 +51,35 @@ describe('convert', () => {
 		}
 	})
 
+	test('the convert fn parses wide-gamut and CIE color spaces', () => {
+		// All of these are equivalent to `red` (#ff0000)
+		const colors = [
+			'lab(54.2905414047 80.8049283205 69.8909647686)',
+			'lch(54.2905414047 106.8371817167 40.8576564524)',
+			'hwb(0 0% 0%)',
+			'color(display-p3 0.9174875573 0.2002868079 0.1385605911)',
+			'color(a98-rgb 0.8585916023 0 0)',
+			'color(prophoto-rgb 0.7022480752 0.275720531 0.1035476647)',
+			'color(rec2020 0.7919771358 0.2309756849 0.0737614751)',
+		]
+
+		for (let color of colors) {
+			let converted = convert(color)
+			let hue_distance = Math.min(converted.hue, 360 - converted.hue)
+			expect(hue_distance, `Failed hue for '${color}', got ${converted.hue}`).toBeLessThan(0.01)
+			expect(
+				converted.saturation,
+				`Failed saturation for '${color}', got ${converted.saturation}`,
+			).toBeGreaterThan(99.9)
+			expect(
+				converted.lightness,
+				`Failed lightness for '${color}', got ${converted.lightness}`,
+			).toBeCloseTo(50, 1)
+			expect(converted.alpha).toBe(1)
+			expect(converted.authored).toBe(color)
+		}
+	})
+
 	const invalid_colors = ['hsl(0, 0, 0)', 'rgb(0 0 0 1)', 'rgb(a, b, c, 1)']
 	test.each(invalid_colors)(`invalid colors return a default object: %s`, (color) => {
 		expect(convert(color)).toEqual({

--- a/index.ts
+++ b/index.ts
@@ -14,6 +14,11 @@ import names from '@colordx/core/plugins/names'
 // syntax, which @colordx/core doesn't support yet (colordx.dev roadmap).
 extend([lab, lch, hwb, hsv, p3, rec2020, a98rgb, prophoto, names])
 
+// High enough to preserve near-full float precision, since `compare()`
+// relies on tiny lightness differences to break ties before falling
+// back to alphabetical sorting.
+const HSL_PRECISION = 15
+
 export type NormalizedColor = {
 	hue: number
 	saturation: number
@@ -49,7 +54,7 @@ export function convert(authored: string): NormalizedColorWithAuthored {
 		}
 	}
 
-	let hsl = color.toHsl(15)
+	let hsl = color.toHsl(HSL_PRECISION)
 
 	return {
 		hue: numerify(hsl.h),

--- a/index.ts
+++ b/index.ts
@@ -1,56 +1,18 @@
-import {
-	tryColor,
-	ColorSpace,
-	XYZ_D65,
-	XYZ_D50,
-	XYZ_ABS_D65,
-	Lab_D65,
-	Lab,
-	LCH,
-	sRGB_Linear,
-	sRGB,
-	HSL,
-	HWB,
-	HSV,
-	P3_Linear,
-	P3,
-	A98RGB_Linear,
-	A98RGB,
-	ProPhoto_Linear,
-	ProPhoto,
-	REC_2020_Linear,
-	REC_2020,
-	OKLab,
-	OKLCH,
-	OKLrab,
-	to as convertColor,
-} from 'colorjs.io/fn'
+import { colordx, extend } from '@colordx/core'
+import lab from '@colordx/core/plugins/lab'
+import lch from '@colordx/core/plugins/lch'
+import hwb from '@colordx/core/plugins/hwb'
+import hsv from '@colordx/core/plugins/hsv'
+import p3 from '@colordx/core/plugins/p3'
+import rec2020 from '@colordx/core/plugins/rec2020'
+import a98rgb from '@colordx/core/plugins/a98rgb'
+import prophoto from '@colordx/core/plugins/prophoto'
+import names from '@colordx/core/plugins/names'
 
-// Register color spaces for parsing and converting
-// TODO: According to the changelog we should be able to import
-// and register all spaces in one go but it doesn't seem to work
-ColorSpace.register(sRGB) // Parses keywords and hex colors
-ColorSpace.register(XYZ_D65)
-ColorSpace.register(XYZ_D50)
-ColorSpace.register(XYZ_ABS_D65)
-ColorSpace.register(Lab_D65)
-ColorSpace.register(Lab)
-ColorSpace.register(LCH)
-ColorSpace.register(sRGB_Linear)
-ColorSpace.register(HSL)
-ColorSpace.register(HWB)
-ColorSpace.register(HSV)
-ColorSpace.register(P3_Linear)
-ColorSpace.register(P3)
-ColorSpace.register(A98RGB_Linear)
-ColorSpace.register(A98RGB)
-ColorSpace.register(ProPhoto_Linear)
-ColorSpace.register(ProPhoto)
-ColorSpace.register(REC_2020_Linear)
-ColorSpace.register(REC_2020)
-ColorSpace.register(OKLab)
-ColorSpace.register(OKLCH)
-ColorSpace.register(OKLrab)
+// Register color spaces for parsing and converting.
+// Not registered: `color(srgb ...)` / `color(srgb-linear ...)` function
+// syntax, which @colordx/core doesn't support yet (colordx.dev roadmap).
+extend([lab, lch, hwb, hsv, p3, rec2020, a98rgb, prophoto, names])
 
 export type NormalizedColor = {
 	hue: number
@@ -75,9 +37,9 @@ function numerify(value: number | null | undefined): number {
  * @example convert('red')
  */
 export function convert(authored: string): NormalizedColorWithAuthored {
-	let parsed = tryColor(authored)
+	let color = colordx(authored)
 
-	if (parsed === null) {
+	if (!color.isValid()) {
 		return {
 			hue: 0,
 			saturation: 0,
@@ -87,18 +49,13 @@ export function convert(authored: string): NormalizedColorWithAuthored {
 		}
 	}
 
-	let converted = parsed.space.id === 'hsl' ? parsed : convertColor(parsed, HSL)
-	let hsl = converted.coords
-	let hue = numerify(hsl[0])
-	let saturation = numerify(hsl[1])
-	let lightness = numerify(hsl[2])
-	let alpha = numerify(converted.alpha)
+	let hsl = color.toHsl(15)
 
 	return {
-		hue,
-		saturation,
-		lightness,
-		alpha,
+		hue: numerify(hsl.h),
+		saturation: numerify(hsl.s),
+		lightness: numerify(hsl.l),
+		alpha: numerify(hsl.alpha),
 		authored,
 	}
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 		"format": "oxfmt"
 	},
 	"dependencies": {
-		"colorjs.io": "~0.7.1"
+		"@colordx/core": "^5.5.0"
 	},
 	"devDependencies": {
 		"@vitest/coverage-v8": "^4.1.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,9 @@ importers:
 
   .:
     dependencies:
-      colorjs.io:
-        specifier: ~0.7.1
-        version: 0.7.1
+      '@colordx/core':
+        specifier: ^5.5.0
+        version: 5.5.0
     devDependencies:
       '@vitest/coverage-v8':
         specifier: ^4.1.10
@@ -59,6 +59,9 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@colordx/core@5.5.0':
+    resolution: {integrity: sha512-3PxTH8itZzltK0U9jTwVVnjLXvnDYuq3m+QXsHkENxWiPRh4WaoLcs1SQjqgZ55kS+QyirpH5BVwzP2gMVG6EQ==}
 
   '@emnapi/core@2.0.0-alpha.3':
     resolution: {integrity: sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g==}
@@ -757,9 +760,6 @@ packages:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
-  colorjs.io@0.7.1:
-    resolution: {integrity: sha512-LY7OHnJZxHwT5UlzNa9bbhHHDbzB6yE5+3MIPwJEQKRvSCt/T4G7epsj+9j2BExUIIfXFIJGsIXUKdfrK9Q5tA==}
-
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
@@ -1236,6 +1236,8 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
+  '@colordx/core@5.5.0': {}
+
   '@emnapi/core@2.0.0-alpha.3':
     dependencies:
       '@emnapi/wasi-threads': 2.0.1
@@ -1657,8 +1659,6 @@ snapshots:
   cac@7.0.0: {}
 
   chai@6.2.2: {}
-
-  colorjs.io@0.7.1: {}
 
   convert-source-map@2.0.0: {}
 


### PR DESCRIPTION
## Summary

- Swap the `colorjs.io` dependency for [`@colordx/core`](https://colordx.dev), a smaller, tree-shakeable color library.
- Re-implement `convert()` on top of `colordx()` / `.toHsl()` instead of `tryColor()` + `to(HSL)`.
- Register colordx's plugins (`lab`, `lch`, `hwb`, `hsv`, `p3`, `rec2020`, `a98rgb`, `prophoto`, `names`) to keep parsing support for the same color spaces the old `ColorSpace.register(...)` calls covered.
- Add test coverage for the wide-gamut / CIE formats (`lab()`, `lch()`, `hwb()`, `color(display-p3 ...)`, `color(a98-rgb ...)`, `color(prophoto-rgb ...)`, `color(rec2020 ...)`) to lock in parsing parity going forward.

## Color space parity

Every color space the old setup registered is still parseable, **except**:

- `color(srgb ...)` and `color(srgb-linear ...)` function syntax — not yet supported by `@colordx/core` ([on their roadmap](https://github.com/dkryaklin/colordx)). These are rarely authored directly in the wild (`rgb()` / hex cover the same gamut), so the trade-off seemed worth it. `rgb()`, `rgba()`, and hex are of course unaffected.
- A few colorjs.io-only, non-standard extensions that were registered but aren't real CSS syntax anyway (`OKLrab`, `Lab-D65`, absolute `XYZ_ABS_D65`) — these were never reachable through an actual CSS color string.

Everything else — hex, `rgb()`, `hsl()`, `hwb()`, `hsv()`, named colors, `lab()`, `lch()`, `oklab()`, `oklch()`, and the `color()` function for `display-p3`, `a98-rgb`, `prophoto-rgb`, `rec2020`, `xyz-d50`, and `xyz-d65` — parses the same as before. All 24 existing tests pass unchanged, plus 1 new test covering the wide-gamut formats above.

## Bundle size

Measured by bundling the full public API (`convert`, `sort_fn`, `compare`, `color_group`) together with its color dependency, minified and tree-shaken with esbuild — i.e. what a consuming app actually ships to the browser:

| | Before (colorjs.io) | After (@colordx/core) | Change |
|---|---|---|---|
| Minified | 54.6 KB | 40.7 KB | **-25.5%** |
| Minified + gzip | 22.8 KB | 12.4 KB | **-45.7%** |
| Minified + brotli | 19.8 KB | 10.6 KB | **-46.5%** |

The package's own `dist/index.js` (excluding the dependency, which is external in the published package) also shrinks slightly: 4.17 KB → 3.73 KB raw, 1.57 KB → 1.48 KB gzip.

## Install size

`node_modules` footprint of the color dependency itself (npm's `unpackedSize`, confirmed with a real `npm install`):

| | Before (colorjs.io@0.7.1) | After (@colordx/core@5.5.0) | Change |
|---|---|---|---|
| Unpacked size | 15.05 MB (15,781,049 B) | 890 KB (911,447 B) | **-94.2%** |

colorjs.io ships its full source, docs, and multiple build outputs in the published tarball even though only `colorjs.io/fn` is imported here; `@colordx/core` publishes just its `dist/` output, so the install footprint drops from ~15 MB to well under 1 MB.

## Test plan

- [x] `pnpm vitest run` — 25/25 tests pass
- [x] `pnpm run check` (tsc --noEmit)
- [x] `pnpm run lint` (oxlint + oxfmt)
- [x] `pnpm run build` (tsdown + publint)
